### PR TITLE
Fix missing CSS in production

### DIFF
--- a/app/routes/articles_._index/articles.jsx
+++ b/app/routes/articles_._index/articles.jsx
@@ -14,6 +14,8 @@ import { formatDate } from '~/utils/date';
 import { classes, cssProps } from '~/utils/style';
 import styles from './articles.module.css';
 
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+
 function ArticlesPost({ slug, frontmatter, timecode, index }) {
   const [hovered, setHovered] = useState(false);
   const [dateTime, setDateTime] = useState(null);

--- a/app/routes/contact/contact.jsx
+++ b/app/routes/contact/contact.jsx
@@ -15,6 +15,8 @@ import { cssProps, msToNum, numToMs } from '~/utils/style';
 import { baseMeta } from '~/utils/meta';
 import styles from './contact.module.css';
 
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+
 export const meta = () => {
   return baseMeta({
     title: 'Contact',

--- a/app/routes/home/home.jsx
+++ b/app/routes/home/home.jsx
@@ -18,26 +18,33 @@ import { ProjectSummary } from './project-summary';
 import { useEffect, useRef, useState } from 'react';
 import config from '~/config.json';
 import styles from './home.module.css';
+import introStyles from './intro.module.css';
+import profileStyles from './profile.module.css';
+import projectSummaryStyles from './project-summary.module.css';
+import displacementSphereStyles from './displacement-sphere.module.css';
 
 // Prefetch draco decoader wasm
-export const links = () => {
-  return [
-    {
-      rel: 'prefetch',
-      href: '/draco/draco_wasm_wrapper.js',
-      as: 'script',
-      type: 'text/javascript',
-      importance: 'low',
-    },
-    {
-      rel: 'prefetch',
-      href: '/draco/draco_decoder.wasm',
-      as: 'fetch',
-      type: 'application/wasm',
-      importance: 'low',
-    },
-  ];
-};
+export const links = () => [
+  { rel: 'stylesheet', href: styles },
+  { rel: 'stylesheet', href: introStyles },
+  { rel: 'stylesheet', href: profileStyles },
+  { rel: 'stylesheet', href: projectSummaryStyles },
+  { rel: 'stylesheet', href: displacementSphereStyles },
+  {
+    rel: 'prefetch',
+    href: '/draco/draco_wasm_wrapper.js',
+    as: 'script',
+    type: 'text/javascript',
+    importance: 'low',
+  },
+  {
+    rel: 'prefetch',
+    href: '/draco/draco_decoder.wasm',
+    as: 'fetch',
+    type: 'application/wasm',
+    importance: 'low',
+  },
+];
 
 export const meta = () => {
   return baseMeta({

--- a/app/routes/projects.about-me/armor.jsx
+++ b/app/routes/projects.about-me/armor.jsx
@@ -28,6 +28,8 @@ import { cleanRenderer, cleanScene, modelLoader, removeLights } from '~/utils/th
 import { throttle } from '~/utils/throttle';
 import styles from './armor.module.css';
 
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+
 const rotationSpringConfig = {
   stiffness: 40,
   damping: 20,

--- a/app/routes/projects.about-me/volkihar-knight.jsx
+++ b/app/routes/projects.about-me/volkihar-knight.jsx
@@ -18,6 +18,8 @@ import { media } from '~/utils/style';
 import { baseMeta } from '~/utils/meta';
 import styles from './volkihar-knight.module.css';
 
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+
 /* --- Assets -------------------------------------------------------------- */
 import Background1Large        from '~/assets/gamingpc.jpg';
 import Background1Placeholder  from '~/assets/gamingpc.jpg';

--- a/app/routes/projects.businesses/earth.jsx
+++ b/app/routes/projects.businesses/earth.jsx
@@ -55,6 +55,8 @@ import {
 import { throttle } from '~/utils/throttle';
 import styles from './earth.module.css';
 
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+
 const nullTarget = { x: 0, y: 0, z: 2 };
 
 const interpolatePosition = (value, nextValue, percent) =>

--- a/app/routes/projects.businesses/smart-sparrow.jsx
+++ b/app/routes/projects.businesses/smart-sparrow.jsx
@@ -58,6 +58,8 @@ import { Suspense, lazy, useMemo } from 'react';
 import { media } from '~/utils/style';
 import styles from './smart-sparrow.module.css';
 
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+
 const Earth = lazy(() => import('./earth').then(module => ({ default: module.Earth })));
 const EarthSection = lazy(() =>
   import('./earth').then(module => ({ default: module.EarthSection }))

--- a/app/routes/projects.collabs/slice.jsx
+++ b/app/routes/projects.collabs/slice.jsx
@@ -40,6 +40,8 @@ import { media } from '~/utils/style';
 import { baseMeta } from '~/utils/meta';
 import styles from './slice.module.css';
 
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+
 const title = 'Partners I work with';
 const description =
   'In this section, you can see all of the main partners I work with such as Jeenka.';

--- a/app/routes/uses/uses.jsx
+++ b/app/routes/uses/uses.jsx
@@ -17,6 +17,8 @@ import {
 import { baseMeta } from '~/utils/meta';
 import styles from './uses.module.css';
 
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+
 export const meta = () => {
   return baseMeta({
     title: 'Uses',


### PR DESCRIPTION
## Summary
- include CSS modules for all Remix routes
- import and link home page styles

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688341e931d48326a8170b0fd7627337