### PR TITLE
Add compatibility date to Wrangler config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,4 @@
+compatibility_date = "2025-07-25"
 kv_namespaces = [
   { id = "MY_KV", binding="MY_KV" }
 ]


### PR DESCRIPTION
## Summary
- set `compatibility_date` in `wrangler.toml`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68834c88e6dc8326b42b436fbd172dc2