### PR TITLE
Fix compatibility date

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-compatibility_date = "2025-07-25"
+compatibility_date = "2024-09-01"
 kv_namespaces = [
   { id = "MY_KV", binding="MY_KV" }
 ]


### PR DESCRIPTION
## Summary
- set a fixed compatibility date so Cloudflare workers run without errors

## Testing
- `npm run build` *(fails: The service was stopped: write EPIPE)*

------
https://chatgpt.com/codex/tasks/task_e_68834f7a46e88326854fe07be52e1a2c